### PR TITLE
Do multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 # syntax=docker/dockerfile:1
-FROM node:16-alpine
+FROM node:16 AS builder
 EXPOSE 80
 WORKDIR /app
 COPY . .
 RUN yarn install
 RUN yarn compile
+
+FROM node:16-alpine
+EXPOSE 80
+WORKDIR /app
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/dist/node-esm ./dist/node-esm
+RUN yarn install --production --frozen-lockfile
 CMD ["yarn", "launch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
 FROM node:16 AS builder
-EXPOSE 80
 WORKDIR /app
 COPY . .
 RUN yarn install


### PR DESCRIPTION
Mostly for bcrypt since it uses node-gyp and alpine doesn't want to bundle what it takes to make that work but also for security, image size, etc.