### PR TITLE
Add Auth Strategy for Anonymous Users

### DIFF
--- a/src/archive/archive/get/get.auth.spec.ts
+++ b/src/archive/archive/get/get.auth.spec.ts
@@ -1,0 +1,73 @@
+import { ArchiveResponse } from '@xyo-network/sdk-xyo-client-js'
+import { StatusCodes } from 'http-status-codes'
+
+import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../../test'
+
+function getInvalidVersionOfToken(token: string) {
+  const half = Math.floor(token.length / 2)
+  return token.substring(0, half) + 'foo' + token.substring(half)
+}
+
+// TODO: Update getArchive from test util to conditionally take a token
+// instead of doing it here
+const callApi = async (
+  archive: string,
+  token?: string,
+  expectedStatus: StatusCodes = StatusCodes.OK
+): Promise<ArchiveResponse> => {
+  const response = token
+    ? await getArchivist().get(`/archive/${archive}`).auth(token, { type: 'bearer' }).expect(expectedStatus)
+    : await getArchivist().get(`/archive/${archive}`).expect(expectedStatus)
+  return response.body.data
+}
+
+describe.skip('/archive/{:archive}', () => {
+  describe('with public archive', () => {
+    let archive = ''
+    let token = ''
+    beforeAll(async () => {
+      // Create public archive
+      token = await getTokenForNewUser()
+      archive = (await claimArchive(token)).archive
+      await setArchiveAccessControl(token, archive, { accessControl: false })
+    })
+    it('with token absent allows access', async () => {
+      await callApi(archive, undefined, StatusCodes.OK)
+    })
+    it('with token for user who owns the archive allows access', async () => {
+      await callApi(archive, token, StatusCodes.OK)
+    })
+    it('with token for user who does not own the archive allows access', async () => {
+      const newToken = await getTokenForNewUser()
+      await callApi(archive, newToken, StatusCodes.OK)
+    })
+    it('with invalid token does not allow access', async () => {
+      const newToken = getInvalidVersionOfToken(token)
+      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
+    })
+  })
+  describe('with private archive', () => {
+    let archive = ''
+    let token = ''
+    beforeAll(async () => {
+      // Create private archive
+      token = await getTokenForNewUser()
+      archive = (await claimArchive(token)).archive
+      await setArchiveAccessControl(token, archive, { accessControl: true })
+    })
+    it('with token absent does not allow access', async () => {
+      await callApi(archive, undefined, StatusCodes.UNAUTHORIZED)
+    })
+    it('with token for user who owns the archive allows access', async () => {
+      await callApi(archive, token, StatusCodes.OK)
+    })
+    it('with token for user who does not own the archive does not allow access', async () => {
+      const newToken = await getTokenForNewUser()
+      await callApi(archive, newToken, StatusCodes.OK)
+    })
+    it('with invalid token does not allow access', async () => {
+      const newToken = getInvalidVersionOfToken(token)
+      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
+    })
+  })
+})

--- a/src/archive/archive/get/get.auth.spec.ts
+++ b/src/archive/archive/get/get.auth.spec.ts
@@ -1,24 +1,11 @@
 import { ArchiveResponse } from '@xyo-network/sdk-xyo-client-js'
 import { StatusCodes } from 'http-status-codes'
 
-import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../../test'
+import { claimArchive, getArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../../test'
 
 function getInvalidVersionOfToken(token: string) {
   const half = Math.floor(token.length / 2)
   return token.substring(0, half) + 'foo' + token.substring(half)
-}
-
-// TODO: Update getArchive from test util to conditionally take a token
-// instead of doing it here
-const callApi = async (
-  archive: string,
-  token?: string,
-  expectedStatus: StatusCodes = StatusCodes.OK
-): Promise<ArchiveResponse> => {
-  const response = token
-    ? await getArchivist().get(`/archive/${archive}`).auth(token, { type: 'bearer' }).expect(expectedStatus)
-    : await getArchivist().get(`/archive/${archive}`).expect(expectedStatus)
-  return response.body.data
 }
 
 describe.skip('/archive/{:archive}', () => {
@@ -32,18 +19,18 @@ describe.skip('/archive/{:archive}', () => {
       await setArchiveAccessControl(token, archive, { accessControl: false })
     })
     it('with token absent allows access', async () => {
-      await callApi(archive, undefined, StatusCodes.OK)
+      await getArchive(archive, undefined, StatusCodes.OK)
     })
     it('with token for user who owns the archive allows access', async () => {
-      await callApi(archive, token, StatusCodes.OK)
+      await getArchive(archive, token, StatusCodes.OK)
     })
     it('with token for user who does not own the archive allows access', async () => {
       const newToken = await getTokenForNewUser()
-      await callApi(archive, newToken, StatusCodes.OK)
+      await getArchive(archive, newToken, StatusCodes.OK)
     })
     it('with invalid token does not allow access', async () => {
       const newToken = getInvalidVersionOfToken(token)
-      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
+      await getArchive(archive, newToken, StatusCodes.UNAUTHORIZED)
     })
   })
   describe('with private archive', () => {
@@ -56,18 +43,18 @@ describe.skip('/archive/{:archive}', () => {
       await setArchiveAccessControl(token, archive, { accessControl: true })
     })
     it('with token absent does not allow access', async () => {
-      await callApi(archive, undefined, StatusCodes.UNAUTHORIZED)
+      await getArchive(archive, undefined, StatusCodes.UNAUTHORIZED)
     })
     it('with token for user who owns the archive allows access', async () => {
-      await callApi(archive, token, StatusCodes.OK)
+      await getArchive(archive, token, StatusCodes.OK)
     })
     it('with token for user who does not own the archive does not allow access', async () => {
       const newToken = await getTokenForNewUser()
-      await callApi(archive, newToken, StatusCodes.OK)
+      await getArchive(archive, newToken, StatusCodes.OK)
     })
     it('with invalid token does not allow access', async () => {
       const newToken = getInvalidVersionOfToken(token)
-      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
+      await getArchive(archive, newToken, StatusCodes.UNAUTHORIZED)
     })
   })
 })

--- a/src/archive/archive/get/get.spec.ts
+++ b/src/archive/archive/get/get.spec.ts
@@ -9,7 +9,7 @@ describe('/archive', () => {
     await claimArchive(token, archive)
   })
   it('Gets information about the archive', async () => {
-    const response = await getArchive(token, archive)
+    const response = await getArchive(archive, token)
     expect(response.archive).toEqual(archive)
   })
 })

--- a/src/archive/get/DefaultPublicArchives.ts
+++ b/src/archive/get/DefaultPublicArchives.ts
@@ -1,0 +1,8 @@
+import { ArchiveResponse } from '../archiveResponse'
+
+export const defaultPublicArchives: ArchiveResponse[] = [
+  {
+    accessControl: false,
+    archive: 'temp',
+  },
+]

--- a/src/archive/get/get.auth.spec.ts
+++ b/src/archive/get/get.auth.spec.ts
@@ -1,39 +1,31 @@
-import { ArchiveResponse } from '@xyo-network/sdk-xyo-client-js'
 import { StatusCodes } from 'http-status-codes'
 
-import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../test'
+import { claimArchive, getArchives, getTokenForNewUser, setArchiveAccessControl } from '../../test'
 
-function getInvalidVersionOfToken(token: string) {
+const getInvalidVersionOfToken = (token: string) => {
   const half = Math.floor(token.length / 2)
   return token.substring(0, half) + 'foo' + token.substring(half)
 }
 
-// TODO: Update getArchive from test util to conditionally take a token
-// instead of doing it here
-const callApi = async (token?: string, expectedStatus: StatusCodes = StatusCodes.OK): Promise<ArchiveResponse> => {
-  const response = token
-    ? await getArchivist().get('/archive').auth(token, { type: 'bearer' }).expect(expectedStatus)
-    : await getArchivist().get('/archive').expect(expectedStatus)
-  return response.body.data
-}
-
 describe('/archive', () => {
-  let archive = ''
-  let token = ''
-  beforeAll(async () => {
-    // Create public archive
-    token = await getTokenForNewUser()
-    archive = (await claimArchive(token)).archive
-    await setArchiveAccessControl(token, archive, { accessControl: false })
-  })
-  it('with token absent allows access', async () => {
-    await callApi(undefined, StatusCodes.OK)
-  })
-  it('with token allows access', async () => {
-    await callApi(token, StatusCodes.OK)
-  })
-  it('with invalid token does not allow access', async () => {
-    const newToken = getInvalidVersionOfToken(token)
-    await callApi(newToken, StatusCodes.UNAUTHORIZED)
+  describe('with token', () => {
+    let archive = ''
+    let token = ''
+    beforeAll(async () => {
+      // Create public archive
+      token = await getTokenForNewUser()
+      archive = (await claimArchive(token)).archive
+      await setArchiveAccessControl(token, archive, { accessControl: false })
+    })
+    it('supplied allows access', async () => {
+      await getArchives(token, StatusCodes.OK)
+    })
+    it('absent allows access', async () => {
+      await getArchives(undefined, StatusCodes.OK)
+    })
+    it('invalid does not allow access', async () => {
+      const newToken = getInvalidVersionOfToken(token)
+      await getArchives(newToken, StatusCodes.UNAUTHORIZED)
+    })
   })
 })

--- a/src/archive/get/get.auth.spec.ts
+++ b/src/archive/get/get.auth.spec.ts
@@ -1,7 +1,7 @@
 import { ArchiveResponse } from '@xyo-network/sdk-xyo-client-js'
 import { StatusCodes } from 'http-status-codes'
 
-import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../../../test'
+import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../test'
 
 function getInvalidVersionOfToken(token: string) {
   const half = Math.floor(token.length / 2)
@@ -21,7 +21,7 @@ const callApi = async (
   return response.body.data
 }
 
-describe('archiveOwner', () => {
+describe('/archive', () => {
   describe('with public archive', () => {
     let archive = ''
     let token = ''

--- a/src/archive/get/get.auth.spec.ts
+++ b/src/archive/get/get.auth.spec.ts
@@ -10,64 +10,30 @@ function getInvalidVersionOfToken(token: string) {
 
 // TODO: Update getArchive from test util to conditionally take a token
 // instead of doing it here
-const callApi = async (
-  archive: string,
-  token?: string,
-  expectedStatus: StatusCodes = StatusCodes.OK
-): Promise<ArchiveResponse> => {
+const callApi = async (token?: string, expectedStatus: StatusCodes = StatusCodes.OK): Promise<ArchiveResponse> => {
   const response = token
-    ? await getArchivist().get(`/archive/${archive}`).auth(token, { type: 'bearer' }).expect(expectedStatus)
-    : await getArchivist().get(`/archive/${archive}`).expect(expectedStatus)
+    ? await getArchivist().get('/archive').auth(token, { type: 'bearer' }).expect(expectedStatus)
+    : await getArchivist().get('/archive').expect(expectedStatus)
   return response.body.data
 }
 
 describe('/archive', () => {
-  describe('with public archive', () => {
-    let archive = ''
-    let token = ''
-    beforeAll(async () => {
-      // Create public archive
-      token = await getTokenForNewUser()
-      archive = (await claimArchive(token)).archive
-      await setArchiveAccessControl(token, archive, { accessControl: false })
-    })
-    it('with token absent allows access', async () => {
-      await callApi(archive, undefined, StatusCodes.OK)
-    })
-    it('with token for user who owns the archive allows access', async () => {
-      await callApi(archive, token, StatusCodes.OK)
-    })
-    it('with token for user who does not own the archive allows access', async () => {
-      const newToken = await getTokenForNewUser()
-      await callApi(archive, newToken, StatusCodes.OK)
-    })
-    it('with invalid token does not allow access', async () => {
-      const newToken = getInvalidVersionOfToken(token)
-      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
-    })
+  let archive = ''
+  let token = ''
+  beforeAll(async () => {
+    // Create public archive
+    token = await getTokenForNewUser()
+    archive = (await claimArchive(token)).archive
+    await setArchiveAccessControl(token, archive, { accessControl: false })
   })
-  describe('with private archive', () => {
-    let archive = ''
-    let token = ''
-    beforeAll(async () => {
-      // Create private archive
-      token = await getTokenForNewUser()
-      archive = (await claimArchive(token)).archive
-      await setArchiveAccessControl(token, archive, { accessControl: true })
-    })
-    it('with token absent does not allow access', async () => {
-      await callApi(archive, undefined, StatusCodes.UNAUTHORIZED)
-    })
-    it('with token for user who owns the archive allows access', async () => {
-      await callApi(archive, token, StatusCodes.OK)
-    })
-    it('with token for user who does not own the archive does not allow access', async () => {
-      const newToken = await getTokenForNewUser()
-      await callApi(archive, newToken, StatusCodes.OK)
-    })
-    it('with invalid token does not allow access', async () => {
-      const newToken = getInvalidVersionOfToken(token)
-      await callApi(archive, newToken, StatusCodes.UNAUTHORIZED)
-    })
+  it('with token absent allows access', async () => {
+    await callApi(undefined, StatusCodes.OK)
+  })
+  it('with token allows access', async () => {
+    await callApi(token, StatusCodes.OK)
+  })
+  it('with invalid token does not allow access', async () => {
+    const newToken = getInvalidVersionOfToken(token)
+    await callApi(newToken, StatusCodes.UNAUTHORIZED)
   })
 })

--- a/src/archive/get/get.spec.ts
+++ b/src/archive/get/get.spec.ts
@@ -10,17 +10,22 @@ describe('/archive', () => {
     it('the users archives and the default public archives', async () => {
       const claimArchiveResponse = await claimArchive(token)
       const response = await getArchives(token)
+      expect(response.length).toBeGreaterThan(0)
       const actual = response.map((a) => a.archive).sort()
       const expected = [claimArchiveResponse, ...defaultPublicArchives].map((a) => a.archive).sort()
       expect(actual).toEqual(expected)
     })
     it('just the default public archives if the user owns no archives', async () => {
-      expect(await getArchives(token)).toEqual(defaultPublicArchives)
+      const response = await getArchives(token)
+      expect(response.length).toBeGreaterThan(0)
+      expect(response).toEqual(defaultPublicArchives)
     })
   })
   describe('when unauthorized returns', () => {
     it('the default public archives', async () => {
-      expect(await getArchives()).toEqual(defaultPublicArchives)
+      const response = await getArchives()
+      expect(response.length).toBeGreaterThan(0)
+      expect(response).toEqual(defaultPublicArchives)
     })
   })
 })

--- a/src/archive/get/get.spec.ts
+++ b/src/archive/get/get.spec.ts
@@ -1,23 +1,26 @@
 import { claimArchive, getArchives, getTokenForNewUser } from '../../test'
+import { defaultPublicArchives } from './DefaultPublicArchives'
 
 describe('/archive', () => {
-  let token = ''
-  beforeEach(async () => {
-    token = await getTokenForNewUser()
+  describe('when authorized returns', () => {
+    let token = ''
+    beforeEach(async () => {
+      token = await getTokenForNewUser()
+    })
+    it('the users archives and the default public archives', async () => {
+      const claimArchiveResponse = await claimArchive(token)
+      const response = await getArchives(token)
+      const actual = response.map((a) => a.archive).sort()
+      const expected = [claimArchiveResponse, ...defaultPublicArchives].map((a) => a.archive).sort()
+      expect(actual).toEqual(expected)
+    })
+    it('just the default public archives if the user owns no archives', async () => {
+      expect(await getArchives(token)).toEqual(defaultPublicArchives)
+    })
   })
-  it('Returns the users archives', async () => {
-    const claimArchiveResponse = await claimArchive(token)
-    const response = await getArchives(token)
-    expect(response.map((x) => x.archive)).toEqual([claimArchiveResponse.archive])
-  })
-  it('Returns any empty array if the user owns no archives', async () => {
-    expect(await getArchives(token)).toEqual([])
-  })
-})
-
-describe('/archive (noauth)', () => {
-  it('Returns the users archives', async () => {
-    const response = await getArchives()
-    expect(response.map((x) => x.archive)).toEqual(['temp'])
+  describe('when unauthorized returns', () => {
+    it('the default public archives', async () => {
+      expect(await getArchives()).toEqual(defaultPublicArchives)
+    })
   })
 })

--- a/src/archive/get/get.ts
+++ b/src/archive/get/get.ts
@@ -4,13 +4,14 @@ import { RequestHandler } from 'express'
 import { getArchivesByOwner } from '../../lib'
 import { ArchiveResponse } from '../archiveResponse'
 
+export const defaultPublicArchives: ArchiveResponse[] = [{ accessControl: false, archive: 'temp' }]
+
 const handler: RequestHandler<NoReqParams, ArchiveResponse[]> = async (req, res, next) => {
   const { user } = req
   if (!user || !user?.id) {
-    //return the public discoverable archives without auth
-    res.json([{ accessControl: false, archive: 'temp' }])
+    res.json(defaultPublicArchives)
   } else {
-    res.json(await getArchivesByOwner(user.id))
+    res.json([...defaultPublicArchives, ...(await getArchivesByOwner(user.id))])
   }
   next()
 }

--- a/src/archive/get/get.ts
+++ b/src/archive/get/get.ts
@@ -3,15 +3,14 @@ import { RequestHandler } from 'express'
 
 import { getArchivesByOwner } from '../../lib'
 import { ArchiveResponse } from '../archiveResponse'
-
-export const defaultPublicArchives: ArchiveResponse[] = [{ accessControl: false, archive: 'temp' }]
+import { defaultPublicArchives } from './DefaultPublicArchives'
 
 const handler: RequestHandler<NoReqParams, ArchiveResponse[]> = async (req, res, next) => {
-  const { user } = req
-  if (!user || !user?.id) {
+  const id = req?.user?.id
+  if (!id) {
     res.json(defaultPublicArchives)
   } else {
-    res.json([...defaultPublicArchives, ...(await getArchivesByOwner(user.id))])
+    res.json([...defaultPublicArchives, ...(await getArchivesByOwner(id))])
   }
   next()
 }

--- a/src/middleware/auth/index.ts
+++ b/src/middleware/auth/index.ts
@@ -6,11 +6,13 @@ import { getUserMongoSdk, MongoDBUserStore, UserWithoutId } from './model'
 import { getProfile, postSignup, postWalletChallenge } from './routes'
 import {
   adminApiKeyUserSignupStrategy,
+  allowUnauthenticatedStrategyName,
   archiveAccessControlStrategyName,
   archiveApiKeyStrategy,
   archiveApiKeyStrategyName,
   archiveOwnerStrategy,
   configureAdminApiKeyStrategy,
+  configureAllowUnauthenticatedStrategy,
   configureArchiveAccessControlStrategy,
   configureArchiveApiKeyStrategy,
   configureArchiveOwnerStrategy,
@@ -60,9 +62,14 @@ export const requireArchiveAccess: RequestHandler[] = passport.authenticate(
 )
 
 /**
- * Allow anonymous requests
+ * If present, require API key OR JWT to be valid, but if absent, allow anonymous access
  */
-export const allowAnonymous: RequestHandler = (_req, _res, next) => next()
+export const allowAnonymous: RequestHandler = passport.authenticate(
+  [allowUnauthenticatedStrategyName, jwtStrategyName, archiveApiKeyStrategyName],
+  {
+    session: false,
+  }
+)
 
 // Properly initialized after auth is configured
 let respondWithJwt: RequestHandler = () => {
@@ -135,9 +142,10 @@ export const configureAuth: (config: AuthConfig) => Promise<Router> = async (con
   const userStore = new MongoDBUserStore(userMongoSdk)
 
   configureAdminApiKeyStrategy(userStore, apiKey)
+  configureAllowUnauthenticatedStrategy()
+  configureArchiveAccessControlStrategy()
   configureArchiveApiKeyStrategy(userStore)
   configureArchiveOwnerStrategy()
-  configureArchiveAccessControlStrategy()
   respondWithJwt = configureJwtStrategy(secretOrKey)
   configureLocalStrategy(userStore)
   configureWeb3Strategy(userStore)

--- a/src/middleware/auth/index.ts
+++ b/src/middleware/auth/index.ts
@@ -50,7 +50,7 @@ export const requireArchiveOwner: RequestHandler[] = [requireAuth, archiveOwnerS
 
 /**
  * Require that the user can, in some way, access the archive. Either by owning
- * the archive OR by the archive being pulbic (having no access control)
+ * the archive OR by the archive being public (having no access control)
  */
 export const requireArchiveAccess: RequestHandler[] = passport.authenticate(
   [archiveAccessControlStrategyName, jwtStrategyName, archiveApiKeyStrategyName],

--- a/src/middleware/auth/strategy/allowUnauthenticated/allowUnauthenticatedStrategy.ts
+++ b/src/middleware/auth/strategy/allowUnauthenticated/allowUnauthenticatedStrategy.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express'
+import { Strategy, StrategyCreated, StrategyCreatedStatic } from 'passport'
+
+/**
+ * Authentication scheme which allows for unauthenticated requests for use in
+ * routes which provide a satisfactory experience without being logged in but
+ * can provide a richer experience for users who are logged in. If auth is
+ * supplied via API Key or Authorization header, this strategy will fail in
+ * favor in deference to those strategies, allowing those strategies to take
+ * precedence if supplied.
+ */
+export class AllowUnauthenticatedStrategy extends Strategy {
+  constructor(public readonly apiKeyHeader = 'x-api-key') {
+    super()
+  }
+
+  override authenticate(this: StrategyCreated<this, this & StrategyCreatedStatic>, req: Request, _options?: unknown) {
+    try {
+      // NOTE: There should never be multiple of this header but
+      // just to prevent ugliness if someone did send us multiple
+      // we'll grab the 1st one
+      const apiKey =
+        // If the header exists
+        req.headers[this.apiKeyHeader]
+          ? // If there's multiple of the same header
+            Array.isArray(req.headers[this.apiKeyHeader])
+            ? // Grab the first one
+              (req.headers[this.apiKeyHeader] as string[]).shift()
+            : // Otherwise grab the only one
+              (req.headers[this.apiKeyHeader] as string)
+          : // Otherwise undefined
+            undefined
+      if (apiKey) {
+        this.fail('API key header supplied')
+        return
+      }
+
+      const authHeader = req.headers.authorization
+      if (authHeader) {
+        this.fail('Authorization header supplied')
+        return
+      }
+
+      this.success({})
+      return
+    } catch (error) {
+      this.error({ message: 'AllowUnauthenticated Auth Error' })
+    }
+  }
+}

--- a/src/middleware/auth/strategy/allowUnauthenticated/configureAllowUnauthenticatedStrategy.ts
+++ b/src/middleware/auth/strategy/allowUnauthenticated/configureAllowUnauthenticatedStrategy.ts
@@ -1,0 +1,10 @@
+import passport from 'passport'
+
+import { AllowUnauthenticatedStrategy } from './allowUnauthenticatedStrategy'
+
+export const allowUnauthenticatedStrategyName = 'allowUnauthenticated'
+export const allowUnauthenticatedStrategy = passport.authenticate(allowUnauthenticatedStrategyName, { session: false })
+
+export const configureAllowUnauthenticatedStrategy = () => {
+  passport.use(allowUnauthenticatedStrategyName, new AllowUnauthenticatedStrategy())
+}

--- a/src/middleware/auth/strategy/allowUnauthenticated/index.ts
+++ b/src/middleware/auth/strategy/allowUnauthenticated/index.ts
@@ -1,0 +1,1 @@
+export * from './configureAllowUnauthenticatedStrategy'

--- a/src/middleware/auth/strategy/archiveOwner/archiveOwner.spec.ts
+++ b/src/middleware/auth/strategy/archiveOwner/archiveOwner.spec.ts
@@ -1,0 +1,50 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { claimArchive, getArchivist, getTokenForNewUser, setArchiveAccessControl } from '../../../../test'
+
+describe.skip('archiveOwner', () => {
+  describe('with public archive', () => {
+    let archive = ''
+    let token = ''
+    beforeAll(async () => {
+      // Create public archive
+      token = await getTokenForNewUser()
+      archive = (await claimArchive(token)).archive
+      await setArchiveAccessControl(token, archive, { accessControl: false })
+    })
+    it('with token absent allows access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.OK)
+    })
+    it('with token for user who owns the archive allows access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.OK)
+    })
+    it('with token for user who does not own the archive allows access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.OK)
+    })
+    it('with invalid token does not allow access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.UNAUTHORIZED)
+    })
+  })
+  describe('with private archive', () => {
+    let archive = ''
+    let token = ''
+    beforeAll(async () => {
+      // Create private archive
+      token = await getTokenForNewUser()
+      archive = (await claimArchive(token)).archive
+      await setArchiveAccessControl(token, archive, { accessControl: true })
+    })
+    it('with token absent does not allow access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.OK)
+    })
+    it('with token for user who owns the archive allows access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.OK)
+    })
+    it('with token for user who does not own the archive  does not allow access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.UNAUTHORIZED)
+    })
+    it('with invalid token does not allow access', async () => {
+      const response = await getArchivist().get('/').expect(StatusCodes.UNAUTHORIZED)
+    })
+  })
+})

--- a/src/middleware/auth/strategy/index.ts
+++ b/src/middleware/auth/strategy/index.ts
@@ -1,4 +1,5 @@
 export * from './adminApiKey'
+export * from './allowUnauthenticated'
 export * from './archiveAccessControl'
 export * from './archiveApiKey'
 export * from './archiveOwner'

--- a/src/server/addArchiveRoutes.ts
+++ b/src/server/addArchiveRoutes.ts
@@ -1,12 +1,13 @@
 import { Express } from 'express'
 
 import { getArchive, getArchives, getArchiveSettingsKeys, postArchiveSettingsKeys, putArchive } from '../archive'
-import { requireArchiveOwner, requireAuth } from '../middleware'
+import { allowAnonymous, requireArchiveOwner, requireAuth } from '../middleware'
 import { notImplemented } from './notImplemented'
 
 export const addArchiveRoutes = (app: Express) => {
   app.get(
     '/archive',
+    allowAnonymous,
     getArchives
     /* #swagger.tags = ['Archive'] */
     /* #swagger.summary = 'Get list of archives on archivist' */

--- a/src/test/testUtil.spec.ts
+++ b/src/test/testUtil.spec.ts
@@ -147,14 +147,13 @@ export const claimArchive = async (
 }
 
 export const getArchive = async (
-  token: string,
   archive: string,
+  token?: string,
   expectedStatus: StatusCodes = StatusCodes.OK
 ): Promise<ArchiveResponse> => {
-  const response = await getArchivist()
-    .get(`/archive/${archive}`)
-    .auth(token, { type: 'bearer' })
-    .expect(expectedStatus)
+  const response = token
+    ? await getArchivist().get(`/archive/${archive}`).auth(token, { type: 'bearer' }).expect(expectedStatus)
+    : await getArchivist().get(`/archive/${archive}`).expect(expectedStatus)
   return response.body.data
 }
 


### PR DESCRIPTION
Authentication scheme which allows for unauthenticated requests for use in routes which provide a satisfactory experience without being logged in but could also provide a richer experience for users who are logged in. If auth is supplied via API Key or Authorization header, this strategy will fail in deference to those strategies, allowing those strategies to take
precedence if supplied.